### PR TITLE
Fix demo_man version mismatch

### DIFF
--- a/demo_man/config/autorun.yaml
+++ b/demo_man/config/autorun.yaml
@@ -1,4 +1,5 @@
-# config_version=5
+#config_version=5
+
 config:
 - config.yaml
 

--- a/demo_man/config/config.yaml
+++ b/demo_man/config/config.yaml
@@ -1,4 +1,4 @@
-# config_version=5
+#config_version=5
 
 fast:
   ports: COM3, COM4, COM5

--- a/demo_man/config/fast.yaml
+++ b/demo_man/config/fast.yaml
@@ -1,4 +1,5 @@
 #config_version=5
+
 fast:
   ports: COM3, COM4, COM5
 

--- a/demo_man/config/hardware.yaml
+++ b/demo_man/config/hardware.yaml
@@ -1,4 +1,5 @@
-# config_version=5
+#config_version=5
+
 # Demolition Man
 
 machine:

--- a/demo_man/config/keyboard.yaml
+++ b/demo_man/config/keyboard.yaml
@@ -1,4 +1,5 @@
 #config_version=5
+
 keyboard:
   s:
     switch: s_start

--- a/demo_man/config/p_roc.yaml
+++ b/demo_man/config/p_roc.yaml
@@ -1,4 +1,4 @@
-# config_version=5
+#config_version=5
 
 hardware:
   driverboards: wpc

--- a/demo_man/config/shots.yaml
+++ b/demo_man/config/shots.yaml
@@ -1,4 +1,5 @@
-# config_version=5
+#config_version=5
+
 sequence_shots:
   left_orbit:
     switch_sequence: s_upper_left_flipper_gate, s_left_loop

--- a/demo_man/modes/base/config/base.yaml
+++ b/demo_man/modes/base/config/base.yaml
@@ -1,4 +1,5 @@
-# config_version=5
+#config_version=5
+
 mode:
   start_events: ball_starting
   priority: 100

--- a/demo_man/modes/claw_lit_for_major_mode/config/claw_lit_for_major_mode.yaml
+++ b/demo_man/modes/claw_lit_for_major_mode/config/claw_lit_for_major_mode.yaml
@@ -1,4 +1,5 @@
-# config_version=5
+#config_version=5
+
 mode:
   start_events: ball_starting
   stop_events: start_mode1_acmag

--- a/demo_man/modes/combos/config/combos.yaml
+++ b/demo_man/modes/combos/config/combos.yaml
@@ -1,3 +1,4 @@
-# config_version=5
+#config_version=5
+
 mode:
   priority: 200

--- a/demo_man/modes/mode1_acmag/config/mode1_acmag.yaml
+++ b/demo_man/modes/mode1_acmag/config/mode1_acmag.yaml
@@ -1,4 +1,5 @@
-# config_version=5
+#config_version=5
+
 mode:
   start_events: start_mode1_acmag
   stop_events: timer_mode_countdown_complete

--- a/demo_man/modes/skillshot/config/skillshot.yaml
+++ b/demo_man/modes/skillshot/config/skillshot.yaml
@@ -1,4 +1,4 @@
-# config_version=5
+#config_version=5
 
 # Skill shot mode
 # One of the five standup targets is lit, sweeping back-and-forth at a 1s interval. Hit the lit


### PR DESCRIPTION
Due to space between `#` and `config_version` in shebang.

```
ValueError: Error found in file /Users/unrared/Repos/mission_pinball/mpf-examples/demo_man/config/config.yaml: Version mismatch. Expected: #config_version=5 Actual: # config_version=5 Files: /Users/unrare
d/Repos/mission_pinball/mpf-examples/demo_man/config/config.yaml
```